### PR TITLE
[NUTRI-33] passa token para water_goal

### DIFF
--- a/app/api/routers/water_goal.py
+++ b/app/api/routers/water_goal.py
@@ -6,36 +6,33 @@ from sqlalchemy.exc import SQLAlchemyError
 from app.schemas.waterGoal import WaterGoalRead, WaterGoalCreate, WaterGoalUpdate
 from app.crud import crud_water_goal
 from app.db.database import get_db
+from app.dependencies.user import get_user_id
+from app.utils.water_goal import get_water_goal_or_err
 
 router = APIRouter(prefix="/water_goal", tags=["WaterGoal"])
 
-@router.get("/user/{user_id}", response_model=WaterGoalRead, status_code=201)
-def read_water_goal(user_id: int, db: Session = Depends(get_db)):
-  water_goal = crud_water_goal.get_water_goal(db, user_id)
-  if not water_goal:
-    raise HTTPException(status_code=404, detail="Water GOAl not found")
-  return water_goal
+@router.get("/", response_model=WaterGoalRead, status_code=201)
+def read_water_goal(user_id: int = Depends(get_user_id), db: Session = Depends(get_db)):
+  return get_water_goal_or_err(db, user_id)
 
 @router.post("/", response_model=WaterGoalRead, status_code=201)
-def create_water(water_goal:WaterGoalCreate, db: Session = Depends(get_db)):
+def create_water(water_goal:WaterGoalCreate, user_id: int = Depends(get_user_id), db: Session = Depends(get_db)):
   try:
-    return crud_water_goal.create_water_goal(db, water_goal)
+    return crud_water_goal.create_water_goal(db, user_id, water_goal)
   except SQLAlchemyError as err:
     db.rollback()
     print(f"[ERRO] Erro ao criar WATER GOAL: {err}")
     raise
 
-@router.patch("/{user_id}", response_model=WaterGoalRead, status_code=201)
-def update_water_goal(user_id: int, water_goal_data:WaterGoalUpdate, db:Session = Depends(get_db)):
+@router.patch("/", response_model=WaterGoalRead, status_code=201)
+def update_water_goal(water_goal_data:WaterGoalUpdate, user_id: int = Depends(get_user_id), db:Session = Depends(get_db)):
+  get_water_goal_or_err(db, user_id)
   water_goal = crud_water_goal.update_water_goal(db, user_id, water_goal_data)
-  if not water_goal:
-    raise HTTPException(status_code=404, detail="Water goal not found")
   return water_goal
+  
 
-
-@router.delete("/{user_id}", response_model=WaterGoalRead)
-def delete_water_goal(user_id:int, db: Session = Depends(get_db)):
+@router.delete("/", status_code=204)
+def delete_water_goal(user_id: int = Depends(get_user_id), db: Session = Depends(get_db)):
+  get_water_goal_or_err(db, user_id)
   water_goal = crud_water_goal.delete_water_goal(db, user_id)
-  if not  water_goal:
-    raise HTTPException(status_code=404, detail=" Water goal not found")
-  return  water_goal
+  return water_goal

--- a/app/crud/crud_water_goal.py
+++ b/app/crud/crud_water_goal.py
@@ -5,14 +5,13 @@ from app.schemas.waterGoal import WaterGoalCreate, WaterGoalUpdate
 from datetime import datetime, date
 from zoneinfo import ZoneInfo
 
-# import pytz
 
 def get_water_goal(db: Session, user_id:int):
   water_goal = db.query(WaterGoal).filter(WaterGoal.user_id == user_id).first()
   if not water_goal:
     return None
 
-  # tz = pytz.timezone("America/Sao_Paulo")
+
   now_local = datetime.now(ZoneInfo("America/Sao_Paulo"))
   today_local = now_local.date()
 
@@ -29,8 +28,8 @@ def get_water_goal_by_user(db: Session, user_id: int):
   return db.query(WaterGoal).filter(WaterGoal.user_id == user_id).first()
 
 
-def create_water_goal(db: Session, water_goal:WaterGoalCreate):
-  db_water_goal = WaterGoal(**water_goal.model_dump())
+def create_water_goal(db: Session, user_id: int, water_goal:WaterGoalCreate):
+  db_water_goal = WaterGoal(**water_goal.model_dump(), user_id = user_id)
   db.add(db_water_goal)
   db.commit()
   db.refresh(db_water_goal)

--- a/app/schemas/waterGoal.py
+++ b/app/schemas/waterGoal.py
@@ -8,7 +8,7 @@ class WaterGoalBase(BaseModel):
 
 
 class WaterGoalCreate(WaterGoalBase):
-    user_id: Optional[int] = None
+    pass
 
 
 class WaterGoalUpdate(BaseModel):

--- a/app/utils/water_goal.py
+++ b/app/utils/water_goal.py
@@ -1,0 +1,16 @@
+from sqlalchemy.orm import Session
+from fastapi import HTTPException
+from app.crud import crud_water_goal
+
+
+def get_water_goal_or_err(db: Session, user_id: int):
+  water_goal = crud_water_goal.get_water_goal(db, user_id)
+
+  if not water_goal:
+    raise HTTPException(status_code=404, detail="water_goal not found")
+  
+  if water_goal.user_id != user_id:
+    raise HTTPException(status_code=403, detail="Not authorized to access this water_goal")
+
+
+  return water_goal


### PR DESCRIPTION
as rotas passam a ser:
![image](https://github.com/user-attachments/assets/a3248ecc-4fdf-43c6-b71f-63b861a439a8)


elas não pedem id de water_goal pois só deve existir apenas um water_goal por usuario, então decidimos fazer as buscas pelo id do usuario, este é extraido do token